### PR TITLE
add support for Hetzner Cloud instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ module "appx" {
 
   /* Scaling */
   host_count = 2
-  do_type    = "s-1vcpu-2gb"
-  gc_type    = "n1-standard-1"
-  ac_type   = "ecs.sn1ne.large"
+  do_size    = "s-1vcpu-2gb"
+  gc_size    = "n1-standard-1"
+  ac_size    = "ecs.sn1ne.large"
+  he_size    = "cpx21"
+
+  /* Firewall */
   open_ports = ["1234", "2345-3456"]
 }
 ```
@@ -57,3 +60,8 @@ Each cloud provider is optional and can be disabled by setting their respective 
     * `gc_type` - Type of host to provision in Google Cloud. (default: `n1-standard-1`)
     * `gc_data_vol_size` - Size in GiB of the extra data volume. (default: `0`)
     * `gc_root_vol_size` - Size in GiB of the host volume. (default: `15`)
+  * __Hetzner Cloud__
+    * `he_count` - Number of Google Cloud hosts to run.
+    * `he_type` - Type of host to provision in Google Cloud. (default: `n1-standard-1`)
+    * `he_data_vol_size` - Size in GiB of the extra data volume. (default: `0`)
+    * `he_root_vol_size` - Size in GiB of the host volume. (default: `15`)

--- a/main.tf
+++ b/main.tf
@@ -15,4 +15,5 @@ locals {
   ac_count = var.ac_count != -1 ? var.ac_count : var.host_count
   do_count = var.do_count != -1 ? var.do_count : var.host_count
   gc_count = var.gc_count != -1 ? var.gc_count : var.host_count
+  he_count = var.he_count != -1 ? var.he_count : var.host_count
 }

--- a/module_he.tf
+++ b/module_he.tf
@@ -1,0 +1,55 @@
+/* Hetzner Cloud */
+
+variable "he_count" {
+  description = "Number of Hetzner Cloud hosts to run."
+  type        = number
+  default     = -1
+}
+
+variable "he_type" {
+  description = "Size of host to provision in Hetzner Cloud."
+  type        = string
+  default     = "cx11"
+}
+
+variable "he_data_vol_size" {
+  description = "Size in GiB of extra volume for host."
+  type        = number
+  default     = 0
+}
+
+
+module "he-eu-helsinki1" {
+  source = "github.com/status-im/infra-tf-hetzner-cloud"
+
+  /* specific */
+  name  = var.name
+  group = var.group
+  env   = var.env
+  stage = local.stage
+
+  /* scaling */
+  count      = local.he_count > 0 ? 1 : 0
+  host_count = local.he_count
+  type       = var.he_type
+  location   = "ams3"
+
+  /* disks */
+  data_vol_size = var.he_data_vol_size
+
+  /* general */
+  domain     = var.domain
+  cf_zone_id = var.cf_zone_id
+
+  /* firewall */
+  open_tcp_ports = var.open_tcp_ports
+  open_udp_ports = var.open_udp_ports
+}
+
+resource "cloudflare_record" "he-eu-helsinki1" {
+  zone_id = var.cf_zone_id
+  name    = "nodes.he-eu-hel1.${local.fleet}"
+  value   = one(module.he-eu-helsinki1[*].public_ips)[count.index]
+  count   = local.he_count
+  type    = "A"
+}


### PR DESCRIPTION
This is blocked because Terraform still requires credentials for provider even if count is set to zero:
```
│ Error: Missing required argument
│ 
│ The argument "token" is required, but was not set.
```
* https://github.com/hashicorp/terraform/issues/31340
* https://github.com/hashicorp/terraform/issues/19932