### PR TITLE
add support for Amazon Web Services EC2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Each cloud provider is optional and can be disabled by setting their respective 
     * `ac_count` - Number of Alibaba Cloud hosts to run.
     * `ac_type` - Type of host to provision in Alibaba Cloud. (default: `ecs.t5-lc1m1.small`)
     * `ac_data_vol_size` - Size in GiB of extra volume for host. (default: `0`)
+  * __Amazon Web Services__
+    * `aws_count` - Number of Alibaba Cloud hosts to run.
+    * `aws_type` - Type of host to provision in Alibaba Cloud. (default: `ecs.t5-lc1m1.small`)
+    * `aws_root_vol_size` - Size in GiB of the host root volume. (default: `15`)
+    * `aws_data_vol_size` - Size in GiB of extra volume for host. (default: `0`)
   * __Digital Ocean__
     * `do_count` - Number of Digital Ocean hosts to run.
     * `do_type` - Type of host to provision in Digital Ocean. (default: `s-1vcpu-1gb`)
@@ -55,5 +60,5 @@ Each cloud provider is optional and can be disabled by setting their respective 
   * __Google Cloud__
     * `gc_count` - Number of Google Cloud hosts to run.
     * `gc_type` - Type of host to provision in Google Cloud. (default: `n1-standard-1`)
+    * `gc_root_vol_size` - Size in GiB of the host root volume. (default: `15`)
     * `gc_data_vol_size` - Size in GiB of the extra data volume. (default: `0`)
-    * `gc_root_vol_size` - Size in GiB of the host volume. (default: `15`)

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,10 @@
 locals {
   stage = var.stage != "" ? var.stage : terraform.workspace
   fleet = "${var.env}.${local.stage}"
+
   /* Counts, default to general count. */
-  ac_count = var.ac_count != -1 ? var.ac_count : var.host_count
-  do_count = var.do_count != -1 ? var.do_count : var.host_count
-  gc_count = var.gc_count != -1 ? var.gc_count : var.host_count
+  ac_count  = var.ac_count  != -1 ? var.ac_count  : var.host_count
+  aws_count = var.aws_count != -1 ? var.aws_count : var.host_count
+  do_count  = var.do_count  != -1 ? var.do_count  : var.host_count
+  gc_count  = var.gc_count  != -1 ? var.gc_count  : var.host_count
 }

--- a/module_aws.tf
+++ b/module_aws.tf
@@ -1,0 +1,91 @@
+/* Amazon Web Services */
+
+variable "aws_count" {
+  description = "Number of AWS hosts to run."
+  type        = number
+  default     = -1
+}
+
+variable "aws_type" {
+  description = "Type of host to provision in AWS."
+  type        = string
+  default     = "n1-standard-1"
+}
+
+variable "aws_root_vol_size" {
+  description = "Size in GiB of the host root volume."
+  type        = number
+  default     = 15
+}
+
+variable "aws_data_vol_size" {
+  description = "Size in GiB of extra data volume for instance."
+  type        = number
+  default     = 0
+}
+
+variable "aws_keypair_name" {
+  description = "Name of SSH key pair in AWS."
+  type        = string
+  default     = ""
+}
+
+variable "aws_vpc_id" {
+  description = "ID of the VPC for instances"
+  type        = string
+  default     = ""
+}
+
+variable "aws_subnet_id" {
+  description = "ID of the Subnet for instances"
+  type        = string
+  default     = ""
+}
+
+variable "aws_secgroup_id" {
+  description = "ID of the Security Group for instances"
+  type        = string
+  default     = ""
+}
+
+module "aws-eu-central-1a" {
+  source = "github.com/status-im/infra-tf-amazon-web-services"
+
+  /* specific */
+  name  = var.name
+  group = var.group
+  env   = var.env
+  stage = local.stage
+
+  /* scaling */
+  count      = local.aws_count > 0 ? 1 : 0
+  host_count = local.aws_count
+  type       = var.aws_type
+  zone       = "eu-central-1a"
+
+  /* disks */
+  root_vol_size = var.aws_root_vol_size
+  data_vol_size = var.aws_data_vol_size
+
+  /* general */
+  domain     = var.domain
+  cf_zone_id = var.cf_zone_id
+
+  /* plumbing */
+  keypair_name = var.aws_keypair_name
+  vpc_id       = var.aws_vpc_id
+  subnet_id    = var.aws_subnet_id
+  secgroup_id  = var.aws_secgroup_id
+
+  /* firewall */
+  open_tcp_ports = var.open_tcp_ports
+  open_udp_ports = var.open_udp_ports
+}
+
+resource "cloudflare_record" "aws-eu-central-1a" {
+  zone_id = var.cf_zone_id
+  name    = "nodes.do-ams3.${local.fleet}"
+  value   = one(module.aws-eu-central-1a[*].public_ips)[count.index]
+  count   = local.aws_count
+  type    = "A"
+}

--- a/module_gc.tf
+++ b/module_gc.tf
@@ -13,7 +13,7 @@ variable "gc_type" {
 }
 
 variable "gc_root_vol_size" {
-  description = "Size in GiB of the host volume."
+  description = "Size in GiB of the host root volume."
   type        = number
   default     = 15
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,23 +1,26 @@
 output "public_ips" {
   value = flatten([
+    one(module.ac-cn-hongkong-c[*].public_ips),
+    one(module.aws-eu-central-1a[*].public_ips),
     one(module.do-eu-amsterdam3[*].public_ips),
     one(module.gc-us-central1-a[*].public_ips),
-    one(module.ac-cn-hongkong-c[*].public_ips),
   ])
 }
 
 output "hosts" {
   value = merge(
+    one(module.ac-cn-hongkong-c[*].hosts),
+    one(module.aws-eu-central-1a[*].hosts),
     one(module.do-eu-amsterdam3[*].hosts),
     one(module.gc-us-central1-a[*].hosts),
-    one(module.ac-cn-hongkong-c[*].hosts),
   )
 }
 
 output "hosts_by_dc" {
   value = {
-    "do-eu-amsterdam3" = one(module.do-eu-amsterdam3[*].hosts)
-    "gc-us-central1-a" = one(module.gc-us-central1-a[*].hosts)
-    "ac-cn-hongkong-c" = one(module.ac-cn-hongkong-c[*].hosts)
+    "ac-cn-hongkong-c"  = one(module.ac-cn-hongkong-c[*].hosts)
+    "aws-eu-central-1a" = one(module.aws-eu-central-1a[*].hosts)
+    "do-eu-amsterdam3"  = one(module.do-eu-amsterdam3[*].hosts)
+    "gc-us-central1-a"  = one(module.gc-us-central1-a[*].hosts)
   }
 }


### PR DESCRIPTION
This is blocked because Terraform still requires credentials for provider even if count is set to zero:
```
│ Error: Missing required argument
│ 
│ The argument "region" is required, but was not set.
```
* https://github.com/hashicorp/terraform/issues/31340
* https://github.com/hashicorp/terraform/issues/19932